### PR TITLE
Re-add support for linode: Revert "Remove linode from xcaddy build options"

### DIFF
--- a/caddy.sh
+++ b/caddy.sh
@@ -27,8 +27,6 @@ rm xcaddy_${version}_linux_$arch.tar.gz
 # panic: internal error: can't find reason for requirement on google.golang.org/appengine@v1.6.6
 # panic: internal error: can't find reason for requirement on google.golang.org/pprof
 
-#  --with github.com/caddy-dns/linode \
-
 ./xcaddy build ${1:-latest} \
   --with github.com/caddy-dns/alidns \
   --with github.com/caddy-dns/azure \
@@ -39,6 +37,7 @@ rm xcaddy_${version}_linux_$arch.tar.gz
   --with github.com/caddy-dns/duckdns \
   --with github.com/caddy-dns/gandi \
   --with github.com/caddy-dns/hetzner \
+  --with github.com/caddy-dns/linode \
   --with github.com/caddy-dns/namecheap \
   --with github.com/caddy-dns/ovh \
   --with github.com/caddy-dns/porkbun \


### PR DESCRIPTION
This reverts commit 7b29d861b68c2768497936ace95bd586c7386345.

Since merging https://github.com/caddy-dns/linode/pull/9 (released as `v0.8.0`), `caddy-dns/linode` again builds on latest Caddy. 

I don't have `dpkg` (I use arch btw), so I wasn't able to test `caddy.sh` directly, but I was able to build caddy using `caddy-dns/linode`:

```bash
$ xcaddy build --with github.com/caddy-dns/linode@v0.8.0
[...]
././caddy version
v2.10.2 h1:g/gTYjGMD0dec+UgMw8SnfmJ3I9+M2TdvoRL/Ovu6U8=
```
Works on my site to complete ACME DNS-01 challenges, but not ECH due to linode limitations (does not support required record type). 